### PR TITLE
[HOT-FIX] Fix line in AndroidManifest preventing launch

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".main.MainActivity"/>
+        <activity android:name="ch.epfl.sweng.swenggolf.main.MainActivity"/>
 
         <activity android:name="ch.epfl.sweng.swenggolf.main.MainMenuActivity"/>
 


### PR DESCRIPTION
Added the name of the package in which the MainActivity is included.

The app should now launch correctly from Android Studio.